### PR TITLE
Add default_app_config to __init__.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,21 @@ requires `/` to return `200 OK`, unless configured differently in EB.
 
 ## Installation
 
-Simply add `ebhealthcheck` to your `INSTALLED_APPS`:
+Simply add `ebhealthcheck` or `ebhealthcheck.apps.EBHealthCheckConfig` to your
+`INSTALLED_APPS`:
 
 ```
 INSTALLED_APPS = [
     ...
     'ebhealthcheck',
+    ...
+]
+```
+
+```
+INSTALLED_APPS = [
+    ...
+    'ebhealthcheck.apps.EBHealthCheckConfig',
     ...
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ requires `/` to return `200 OK`, unless configured differently in EB.
 
 ## Installation
 
-Simply add `ebhealthcheck.apps.EBHealthCheckConfig` to your `INSTALLED_APPS`:
+Simply add `ebhealthcheck` to your `INSTALLED_APPS`:
 
 ```
 INSTALLED_APPS = [
     ...
-    'ebhealthcheck.apps.EBHealthCheckConfig',
+    'ebhealthcheck',
     ...
 ]
 ```

--- a/ebhealthcheck/__init__.py
+++ b/ebhealthcheck/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ebhealthcheck.apps.EBHealthCheckConfig'


### PR DESCRIPTION
This allows the app to be added to `INSTALLED_APPS` as `ebhealthcheck` instead of `ebhealthcheck.apps.EBHealthCheckConfig`.