### PR TITLE
retry when InvalidHeader is raised

### DIFF
--- a/ebhealthcheck/apps.py
+++ b/ebhealthcheck/apps.py
@@ -25,7 +25,7 @@ class EBHealthCheckConfig(AppConfig):
                     ip = requests.get(metadata_url + "/meta-data/local-ipv4", timeout=0.1, headers={
                         "X-aws-ec2-metadata-token": token,
                     }).text
-                except requests.exceptions.ConnectionError:
+                except (requests.exceptions.ConnectionError, requests.exceptions.InvalidHeader):
                     n += 1
                     continue
                 else:


### PR DESCRIPTION
Fix sporadic "Invalid return character or leading space in header: X-aws-ec2-metadata-token" error from the requests lib.
Fixes #4